### PR TITLE
Update of Bunny url on locales README files

### DIFF
--- a/lang/README_ru.md
+++ b/lang/README_ru.md
@@ -143,7 +143,7 @@ pnpm inject
 ### Установить плагин через URL
 
 ```
-https://fakeprofile.sampath.tech/
+https://bunnyfakeprofile.is-always.online/
 ```
 
 </details>

--- a/lang/README_vi.md
+++ b/lang/README_vi.md
@@ -142,7 +142,7 @@ pnpm build
 ### Cài đặt với URL plugin
 
 ```
-https://fakeprofile.sampath.tech/
+https://bunnyfakeprofile.is-always.online/
 ```
 
 </details>


### PR DESCRIPTION
The url of Bunny only updated for English version(https://github.com/gujarathisampath/fakeProfile/commit/7e7fab0065628b53cbaa5380ab6b3904b2d18061), but also it needs for other README files.